### PR TITLE
Add digest() shortcut to Algorithm

### DIFF
--- a/src/main/php/text/hash/AlgorithmV5.class.php
+++ b/src/main/php/text/hash/AlgorithmV5.class.php
@@ -9,6 +9,17 @@ class AlgorithmV5 {
   }
 
   /**
+   * Shortcut for `new()->digest()`.
+   *
+   * @param  string $string
+   * @param  var... $args
+   * @return text.hash.HashCode
+   */
+  public function digest($string, ... $args) {
+    return $this->f['new'](...$args)->digest($string);
+  }
+
+  /**
    * Instantiates the algorithm (call interceptot for `$algo->new()`).
    *
    * @param  string $name

--- a/src/main/php/text/hash/AlgorithmV7.class.php
+++ b/src/main/php/text/hash/AlgorithmV7.class.php
@@ -9,6 +9,17 @@ class AlgorithmV7 {
   }
 
   /**
+   * Shortcut for `new()->digest()`.
+   *
+   * @param  string $string
+   * @param  var... $args
+   * @return text.hash.HashCode
+   */
+  public function digest($string, ... $args) {
+    return ($this->new)(...$args)->digest($string);
+  }
+
+  /**
    * Instantiates the algorithm
    *
    * @param  var... $args

--- a/src/test/php/text/hash/unittest/HashingTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingTest.class.php
@@ -79,4 +79,12 @@ class HashingTest extends TestCase {
       Hashing::md5()->new()->digest('Test')
     );
   }
+
+  #[@test]
+  public function digest_shortcut() {
+    $this->assertEquals(
+      Hashing::md5()->digest('Test'),
+      Hashing::md5()->new()->digest('Test')
+    );
+  }
 }


### PR DESCRIPTION
Makes the simplemost usecase shorter:

```php
$hashing= Hashing::sha256();

// Current, returns Algorithm instance, can work with update() and digest()
$digest= $hashing->new()->digest('Test');

// New shortcut, directly calls Algorithm's digest() method. No way to
// incrementally call update(), need above API for that.
$digest= $hashing->digest('Test');
```
