### PR TITLE
Add support for passing util.Bytes and util.Secret instances

### DIFF
--- a/src/main/php/text/hash/Murmur128.class.php
+++ b/src/main/php/text/hash/Murmur128.class.php
@@ -1,6 +1,7 @@
 <?php namespace text\hash;
 
 use lang\IllegalStateException;
+use util\{Bytes, Secret};
 
 class Murmur128 implements Hash {
   const C1 = '9782798678568883157';
@@ -138,13 +139,21 @@ class Murmur128 implements Hash {
   /**
    * Incrementally update the hash with a string.
    *
-   * @param  string $string
+   * @param  string|util.Bytes|util.Secret $arg
    * @return self
    * @throws lang.IllegalStateException
    */
-  public function update($string) {
+  public function update($arg) {
     if ($this->final) {
       throw new IllegalStateException('Cannot reuse hash');
+    }
+
+    if ($arg instanceof Secret) {
+      $string= $arg->reveal();
+    } else if ($arg instanceof Bytes) {
+      $string= (string)$arg;
+    } else {
+      $string= &$arg;
     }
 
     // Merge remainder with new byte values
@@ -186,7 +195,7 @@ class Murmur128 implements Hash {
   /**
    * Returns the final hash digest
    *
-   * @param  string $string Optional string value
+   * @param  ?string|util.Bytes|util.Secret $arg Optional string value
    * @return text.hash.HashCode
    * @throws lang.IllegalStateException
    */

--- a/src/main/php/text/hash/Murmur32.class.php
+++ b/src/main/php/text/hash/Murmur32.class.php
@@ -1,6 +1,7 @@
 <?php namespace text\hash;
 
 use lang\IllegalStateException;
+use util\{Bytes, Secret};
 
 /**
  * MurmurHash3, 32-bit
@@ -52,13 +53,21 @@ class Murmur32 implements Hash {
   /**
    * Incrementally update the hash with a string.
    *
-   * @param  string $string
+   * @param  string|util.Bytes|util.Secret $arg
    * @return self
    * @throws lang.IllegalStateException
    */
-  public function update($string) {
+  public function update($arg) {
     if ($this->final) {
       throw new IllegalStateException('Cannot reuse hash');
+    }
+
+    if ($arg instanceof Secret) {
+      $string= $arg->reveal();
+    } else if ($arg instanceof Bytes) {
+      $string= (string)$arg;
+    } else {
+      $string= &$arg;
     }
 
     // Merge remainder with new byte values
@@ -91,17 +100,17 @@ class Murmur32 implements Hash {
   /**
    * Returns the final hash digest
    *
-   * @param  string $string Optional string value
+   * @param  ?string|util.Bytes|util.Secret $arg Optional string value
    * @return text.hash.HashCode
    * @throws lang.IllegalStateException
    */
-  public function digest($string= null) {
+  public function digest($arg= null) {
     if ($this->final) {
       throw new IllegalStateException('Cannot reuse hash');
     }
 
-    if (null !== $string) {
-      $this->update($string);
+    if (null !== $arg) {
+      $this->update($arg);
     }
 
     $h= $this->hash;

--- a/src/test/php/text/hash/unittest/HashingTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingTest.class.php
@@ -3,6 +3,7 @@
 use lang\{IllegalArgumentException, IllegalStateException};
 use text\hash\Hashing;
 use unittest\{Expect, Test, TestCase, Values};
+use util\{Secret, Bytes};
 
 class HashingTest extends TestCase {
 
@@ -73,5 +74,19 @@ class HashingTest extends TestCase {
 
     $fixture->digest('Test');
     $fixture->digest('Test');
+  }
+
+  #[Test, Values(['md5', 'murmur3_32', 'murmur3_128'])]
+  public function can_pass_secrets($algorithm) {
+    $fixture= Hashing::algorithm($algorithm);
+
+    $this->assertEquals($fixture->new()->digest('test'), $fixture->new()->digest(new Secret('test')));
+  }
+
+  #[Test, Values(['md5', 'murmur3_32', 'murmur3_128'])]
+  public function can_pass_bytes($algorithm) {
+    $fixture= Hashing::algorithm($algorithm);
+
+    $this->assertEquals($fixture->new()->digest('test'), $fixture->new()->digest(new Bytes('test')));
   }
 }

--- a/src/test/php/text/hash/unittest/HashingTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingTest.class.php
@@ -80,13 +80,13 @@ class HashingTest extends TestCase {
   public function can_pass_secrets($algorithm) {
     $fixture= Hashing::algorithm($algorithm);
 
-    $this->assertEquals($fixture->new()->digest('test'), $fixture->new()->digest(new Secret('test')));
+    $this->assertEquals($fixture->digest('test'), $fixture->digest(new Secret('test')));
   }
 
   #[Test, Values(['md5', 'murmur3_32', 'murmur3_128'])]
   public function can_pass_bytes($algorithm) {
     $fixture= Hashing::algorithm($algorithm);
 
-    $this->assertEquals($fixture->new()->digest('test'), $fixture->new()->digest(new Bytes('test')));
+    $this->assertEquals($fixture->digest('test'), $fixture->digest(new Bytes('test')));
   }
 }


### PR DESCRIPTION
This pull request follows the *be liberal in what you accept* paradigm.

```php
use text\hash\Hashing;
use util\Secret;

$passwords= Hashing::sha256();
$secret= new Secret('...');

// Old code
$hash= $this->passwords->digest($secret->reveal())->hex();

// New code
$hash= $this->passwords->digest($secret)->hex();
```