### PR TITLE
Implement hashing I/O streams

### DIFF
--- a/src/main/php/text/hash/HashingInputStream.class.php
+++ b/src/main/php/text/hash/HashingInputStream.class.php
@@ -1,0 +1,56 @@
+<?php namespace text\hash;
+
+use io\streams\InputStream;
+
+/**
+ * An input stream that computes a hash code of the data read from it
+ *
+ * @test  text.hash.unittest.HashingInputStreamTest
+ */
+class HashingInputStream implements InputStream {
+  private $hash, $in;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  text.hash.Hash|text.hash.Algorithm|string $arg
+   * @param  io.streams.InputStream $in
+   */
+  public function __construct($arg, InputStream $in) {
+    if ($arg instanceof Hash) {
+      $this->hash= $arg;
+    } else if ($arg instanceof Algorithm) {
+      $this->hash= $arg->new();
+    } else {
+      $this->hash= Hashing::algorithm((string)$arg)->new();
+    }
+    $this->in= $in;
+  }
+
+  /** @return int */
+  public function available() {
+    return $this->in->available();
+  }
+
+  /**
+   * Read a string
+   *
+   * @param  int $limit
+   * @return string
+   */
+  public function read($limit= 8192) {
+    $bytes= $this->in->read($limit);
+    $this->hash->update($bytes);
+    return $bytes;
+  }
+
+  /** @return void */
+  public function close() {
+    $this->in->close();
+  }
+
+  /** Returns the hash code */
+  public function digest(): HashCode {
+    return $this->hash->digest();
+  }
+}

--- a/src/main/php/text/hash/HashingOutputStream.class.php
+++ b/src/main/php/text/hash/HashingOutputStream.class.php
@@ -1,0 +1,55 @@
+<?php namespace text\hash;
+
+use io\streams\OutputStream;
+
+/**
+ * An output stream that computes a hash code of the data written to it
+ *
+ * @test  text.hash.unittest.HashingOutputStreamTest
+ */
+class HashingOutputStream implements OutputStream {
+  private $hash, $out;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  text.hash.Hash|text.hash.Algorithm|string $arg
+   * @param  io.streams.OutputStream $out
+   */
+  public function __construct($arg, OutputStream $out) {
+    if ($arg instanceof Hash) {
+      $this->hash= $arg;
+    } else if ($arg instanceof Algorithm) {
+      $this->hash= $arg->new();
+    } else {
+      $this->hash= Hashing::algorithm((string)$arg)->new();
+    }
+    $this->out= $out;
+  }
+
+  /**
+   * Write a string
+   *
+   * @param  var $arg
+   * @return void
+   */
+  public function write($bytes) {
+    $this->out->write($bytes);
+    $this->hash->update($bytes);
+  }
+
+  /** @return void */
+  public function flush() {
+    $this->out->flush();
+  }
+
+  /** @return void */
+  public function close() {
+    $this->out->close();
+  }
+
+  /** Returns the hash code */
+  public function digest(): HashCode {
+    return $this->hash->digest();
+  }
+}

--- a/src/test/php/text/hash/unittest/HashingInputStreamTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingInputStreamTest.class.php
@@ -14,11 +14,15 @@ class HashingInputStreamTest {
   }
 
   #[Test]
+  public function data_is_available_from_underlying_stream() {
+    $fixture= new HashingInputStream('sha256', new MemoryInputStream('Test'));
+    Assert::equals(4, $fixture->available());
+  }
+
+  #[Test]
   public function data_is_read_from_underlying_stream() {
     $fixture= new HashingInputStream('sha256', new MemoryInputStream('Test'));
-    $bytes= $fixture->read();
-
-    Assert::equals('Test', $bytes);
+    Assert::equals('Test', $fixture->read());
   }
 
   #[Test, Values(from: 'arguments')]

--- a/src/test/php/text/hash/unittest/HashingInputStreamTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingInputStreamTest.class.php
@@ -1,0 +1,47 @@
+<?php namespace text\hash\unittest;
+
+use io\streams\MemoryInputStream;
+use test\{Assert, Test, Values};
+use text\hash\{Hashing, HashingInputStream};
+
+class HashingInputStreamTest {
+
+  /** @return iterable */
+  private function arguments() {
+    yield ['name', 'sha256'];
+    yield ['algorithm', Hashing::sha256()];
+    yield ['hash', Hashing::sha256()->new()];
+  }
+
+  #[Test]
+  public function data_is_read_from_underlying_stream() {
+    $fixture= new HashingInputStream('sha256', new MemoryInputStream('Test'));
+    $bytes= $fixture->read();
+
+    Assert::equals('Test', $bytes);
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_from($kind, $argument) {
+    $fixture= new HashingInputStream($argument, new MemoryInputStream('Test'));
+    $fixture->read();
+
+    Assert::equals(Hashing::sha256()->digest('Test'), $fixture->digest());
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_partially($kind, $argument) {
+    $fixture= new HashingInputStream($argument, new MemoryInputStream('ABC'));
+    $fixture->read(1);
+    $fixture->read(1);
+
+    Assert::equals(Hashing::sha256()->digest('AB'), $fixture->digest());
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_without_read($kind, $argument) {
+    $fixture= new HashingInputStream($argument, new MemoryInputStream(''));
+
+    Assert::equals(Hashing::sha256()->digest(''), $fixture->digest());
+  }
+}

--- a/src/test/php/text/hash/unittest/HashingOutputStreamTest.class.php
+++ b/src/test/php/text/hash/unittest/HashingOutputStreamTest.class.php
@@ -1,0 +1,49 @@
+<?php namespace text\hash\unittest;
+
+use io\streams\MemoryOutputStream;
+use test\{Assert, Test, Values};
+use text\hash\{Hashing, HashingOutputStream};
+
+class HashingOutputStreamTest {
+
+  /** @return iterable */
+  private function arguments() {
+    yield ['name', 'sha256'];
+    yield ['algorithm', Hashing::sha256()];
+    yield ['hash', Hashing::sha256()->new()];
+  }
+
+  #[Test]
+  public function data_is_written_to_underlying_stream() {
+    $out= new MemoryOutputStream();
+    $fixture= new HashingOutputStream('sha256', $out);
+    $fixture->write('Test');
+
+    Assert::equals('Test', $out->bytes());
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_from($kind, $argument) {
+    $fixture= new HashingOutputStream($argument, new MemoryOutputStream());
+    $fixture->write('Test');
+
+    Assert::equals(Hashing::sha256()->digest('Test'), $fixture->digest());
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_from_all($kind, $argument) {
+    $fixture= new HashingOutputStream($argument, new MemoryOutputStream());
+    $fixture->write('A');
+    $fixture->write('B');
+    $fixture->write('C');
+
+    Assert::equals(Hashing::sha256()->digest('ABC'), $fixture->digest());
+  }
+
+  #[Test, Values(from: 'arguments')]
+  public function hash_calculated_without_write($kind, $argument) {
+    $fixture= new HashingOutputStream($argument, new MemoryOutputStream());
+
+    Assert::equals(Hashing::sha256()->digest(''), $fixture->digest());
+  }
+}


### PR DESCRIPTION
Example:

```php
use text\hash\HashingOutStream;

$out= new HashingOutputStream('md5', new FileOutputStream('test.txt'));
$out->write('Test');
$out->close();

$md5= $out->digest()->hex(); // md5("Test")
```

See also https://github.com/xp-forge/web/issues/118 and https://www.javadoc.io/doc/com.google.guava/guava/latest/com/google/common/hash/package-summary.html